### PR TITLE
Add config loader package with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ task run:client  --query "Explain BGP?"
 
 ---
 
+## 📝 Go Prototype
+
+An experimental Go server lives in the `golang/` directory.
+
+Build and run it:
+
+```bash
+cd golang
+go build
+./golang
+```
+
+Run the Go tests:
+
+```bash
+go test ./...
+```
+
+---
+
 ## ⚙️ Example Model Config (`src/configs/expert.yaml`)
 
 ```yaml

--- a/golang/config/config.go
+++ b/golang/config/config.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type API struct {
+	URL string
+}
+
+type Model struct {
+	Path string
+}
+
+type ModelConfig struct {
+	API          API
+	Model        Model
+	SystemPrompt string
+}
+
+// LoadAll reads all YAML config files under dir.
+// It ignores non-YAML files and invalid configs.
+func LoadAll(dir string) map[string]ModelConfig {
+	cfgs := make(map[string]ModelConfig)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return cfgs
+	}
+	for _, e := range entries {
+		if e.IsDir() || !(strings.HasSuffix(e.Name(), ".yaml") || strings.HasSuffix(e.Name(), ".yml")) {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		cfg, err := parseSimpleYAML(path)
+		if err != nil {
+			continue
+		}
+		if cfg.API.URL == "" && cfg.Model.Path == "" && cfg.SystemPrompt == "" {
+			// treat empty config as invalid
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+		cfgs[id] = cfg
+	}
+	return cfgs
+}
+
+// parseSimpleYAML parses a minimal subset of YAML used by the configs.
+func parseSimpleYAML(path string) (ModelConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return ModelConfig{}, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var cfg ModelConfig
+	section := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, ":") {
+			section = strings.TrimSuffix(line, ":")
+			continue
+		}
+		switch {
+		case section == "api" && strings.HasPrefix(line, "url:"):
+			cfg.API.URL = strings.TrimSpace(strings.TrimPrefix(line, "url:"))
+		case section == "model" && strings.HasPrefix(line, "path:"):
+			cfg.Model.Path = strings.TrimSpace(strings.TrimPrefix(line, "path:"))
+		case strings.HasPrefix(line, "system_prompt:"):
+			cfg.SystemPrompt = strings.TrimSpace(strings.TrimPrefix(line, "system_prompt:"))
+		default:
+			// unrecognized line -> mark invalid
+			return ModelConfig{}, os.ErrInvalid
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ModelConfig{}, err
+	}
+	return cfg, nil
+}

--- a/golang/config/config_test.go
+++ b/golang/config/config_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAllValid(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "foo.yaml")
+	os.WriteFile(cfgPath, []byte("api:\n  url: http://x\nmodel:\n  path: m\nsystem_prompt: hi"), 0o644)
+
+	cfgs := LoadAll(dir)
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(cfgs))
+	}
+	cfg := cfgs["foo"]
+	if cfg.API.URL != "http://x" || cfg.Model.Path != "m" || cfg.SystemPrompt != "hi" {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestLoadAllMissingDir(t *testing.T) {
+	cfgs := LoadAll("/nonexistent")
+	if len(cfgs) != 0 {
+		t.Fatalf("expected empty configs, got %d", len(cfgs))
+	}
+}
+
+func TestLoadAllIgnoresNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "ignore.txt"), []byte("bad"), 0o644)
+	os.WriteFile(filepath.Join(dir, "good.yml"), []byte("api:\n  url: u\nmodel:\n  path: p"), 0o644)
+	cfgs := LoadAll(dir)
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(cfgs))
+	}
+	if _, ok := cfgs["good"]; !ok {
+		t.Fatalf("expected good config loaded")
+	}
+}
+
+func TestLoadAllSkipsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(":::"), 0o644)
+	cfgs := LoadAll(dir)
+	if len(cfgs) != 0 {
+		t.Fatalf("expected no configs, got %d", len(cfgs))
+	}
+}

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,0 +1,3 @@
+module llmwrapper-go
+
+go 1.23.8

--- a/golang/main.go
+++ b/golang/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"llmwrapper-go/config"
+)
+
+type ModelData struct {
+	ID      string `json:"id"`
+	Created int64  `json:"created"`
+}
+
+type ModelList struct {
+	Data []ModelData `json:"data"`
+}
+
+var configs map[string]config.ModelConfig
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func modelsHandler(w http.ResponseWriter, r *http.Request) {
+	list := ModelList{Data: []ModelData{}}
+	for id := range configs {
+		list.Data = append(list.Data, ModelData{ID: id, Created: time.Now().Unix()})
+	}
+	json.NewEncoder(w).Encode(list)
+}
+
+func chatCompletionHandler(w http.ResponseWriter, r *http.Request) {
+	// Placeholder implementation - forward request to configured API
+	var req map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	modelID, _ := req["model"].(string)
+	cfg, ok := configs[modelID]
+	if !ok {
+		http.Error(w, "model not found", http.StatusNotFound)
+		return
+	}
+	// Forward request
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(cfg.API.URL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func main() {
+	configs = config.LoadAll("../src/llm_wrapper/configs")
+	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc("/v1/models", modelsHandler)
+	http.HandleFunc("/v1/chat/completions", chatCompletionHandler)
+	log.Println("starting server on :8000")
+	log.Fatal(http.ListenAndServe(":8000", nil))
+}


### PR DESCRIPTION
## Summary
- implement `golang/config` package with minimal YAML loader
- update Go server to use new loader
- document building and testing the Go prototype

## Testing
- `go test ./...`
- `go build ./...`
- `./local/scripts/run_python.sh pytest -q` *(fails: No route to host)*