### PR TITLE
Continue Go migration

### DIFF
--- a/golang/config/loader.go
+++ b/golang/config/loader.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ModelConfig mirrors the minimal YAML schema used in the Python implementation.
+type ModelConfig struct {
+	API struct {
+		URL string
+	}
+	Model struct {
+		Path string
+	}
+	SystemPrompt string
+}
+
+// ConfigDir defines where configuration YAML files are loaded from.
+var ConfigDir = "../src/llm_wrapper/configs"
+
+// LoadAllConfigs reads all YAML files from ConfigDir and returns them keyed by filename without extension.
+func LoadAllConfigs() map[string]ModelConfig {
+	cfgs := make(map[string]ModelConfig)
+
+	entries, err := os.ReadDir(ConfigDir)
+	if err != nil {
+		log.Printf("failed to read config dir: %v", err)
+		return cfgs
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(e.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		path := filepath.Join(ConfigDir, e.Name())
+		mc, err := parseSimpleYAML(path)
+		if err != nil {
+			log.Printf("failed to load config file %s: %v", e.Name(), err)
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ext)
+		cfgs[id] = mc
+	}
+	return cfgs
+}
+
+// parseSimpleYAML parses the small subset of YAML used in example configs.
+// It only supports keys: api.url, model.path and system_prompt.
+func parseSimpleYAML(path string) (ModelConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return ModelConfig{}, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var cfg ModelConfig
+	section := ""
+	recognized := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasSuffix(line, ":") {
+			section = strings.TrimSuffix(line, ":")
+			continue
+		}
+		if section == "api" && strings.HasPrefix(line, "url:") {
+			cfg.API.URL = strings.TrimSpace(strings.TrimPrefix(line, "url:"))
+			recognized = true
+		} else if section == "model" && strings.HasPrefix(line, "path:") {
+			cfg.Model.Path = strings.TrimSpace(strings.TrimPrefix(line, "path:"))
+			recognized = true
+		} else if strings.HasPrefix(line, "system_prompt:") {
+			cfg.SystemPrompt = strings.TrimSpace(strings.TrimPrefix(line, "system_prompt:"))
+			recognized = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ModelConfig{}, err
+	}
+	if !recognized {
+		return ModelConfig{}, io.ErrUnexpectedEOF
+	}
+	return cfg, nil
+}

--- a/golang/config/loader_test.go
+++ b/golang/config/loader_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helper to create temporary config directory
+func setupTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	ConfigDir = dir
+	return dir
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func TestLoadAllConfigsWithValidYAML(t *testing.T) {
+	dir := setupTempDir(t)
+	writeFile(t, dir, "foo.yaml", "api:\n  url: u\nmodel:\n  path: p\n")
+
+	configs := LoadAllConfigs()
+	cfg, ok := configs["foo"]
+	if !ok {
+		t.Fatalf("expected foo config")
+	}
+	if cfg.API.URL != "u" {
+		t.Errorf("unexpected api.url %q", cfg.API.URL)
+	}
+	if cfg.Model.Path != "p" {
+		t.Errorf("unexpected model.path %q", cfg.Model.Path)
+	}
+}
+
+func TestLoadAllConfigsMissing(t *testing.T) {
+	dir := setupTempDir(t)
+	os.RemoveAll(dir) // remove directory to simulate missing
+	configs := LoadAllConfigs()
+	if len(configs) != 0 {
+		t.Fatalf("expected empty configs")
+	}
+}
+
+func TestLoadAllConfigsIgnoresNonYAML(t *testing.T) {
+	dir := setupTempDir(t)
+	writeFile(t, dir, "ignore.txt", "ignore")
+	writeFile(t, dir, "good.yml", "api:\n  url: u\nmodel:\n  path: p\n")
+
+	configs := LoadAllConfigs()
+	if len(configs) != 1 {
+		t.Fatalf("expected one config, got %d", len(configs))
+	}
+	if _, ok := configs["good"]; !ok {
+		t.Fatalf("expected good config present")
+	}
+}
+
+func TestLoadAllConfigsInvalidYAML(t *testing.T) {
+	dir := setupTempDir(t)
+	writeFile(t, dir, "bad.yaml", "::::")
+
+	configs := LoadAllConfigs()
+	if len(configs) != 0 {
+		t.Fatalf("expected no configs loaded")
+	}
+}

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,0 +1,3 @@
+module llmwrapper-go
+
+go 1.23.8

--- a/golang/main.go
+++ b/golang/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"llmwrapper-go/config"
+)
+
+type ModelData struct {
+	ID      string `json:"id"`
+	Created int64  `json:"created"`
+}
+
+type ModelList struct {
+	Data []ModelData `json:"data"`
+}
+
+var configs map[string]config.ModelConfig
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func modelsHandler(w http.ResponseWriter, r *http.Request) {
+	list := ModelList{Data: []ModelData{}}
+	for id := range configs {
+		list.Data = append(list.Data, ModelData{ID: id, Created: time.Now().Unix()})
+	}
+	json.NewEncoder(w).Encode(list)
+}
+
+func chatCompletionHandler(w http.ResponseWriter, r *http.Request) {
+	// Placeholder implementation - forward request to configured API
+	var req map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	modelID, _ := req["model"].(string)
+	cfg, ok := configs[modelID]
+	if !ok {
+		http.Error(w, "model not found", http.StatusNotFound)
+		return
+	}
+	// Forward request
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(cfg.API.URL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func main() {
+	configs = config.LoadAllConfigs()
+	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc("/v1/models", modelsHandler)
+	http.HandleFunc("/v1/chat/completions", chatCompletionHandler)
+	log.Println("starting server on :8000")
+	log.Fatal(http.ListenAndServe(":8000", nil))
+}


### PR DESCRIPTION
## Summary
- create a `config` package for the Go prototype
- implement YAML loader with basic parsing and tests
- update the Go server to use the loader

## Testing
- `go test ./...`
- `go build ./...`
- `./local/scripts/run_python.sh pytest -q` *(fails: cannot fetch Python packages)*